### PR TITLE
Update the curl option to skip the self signed certificate

### DIFF
--- a/src/Fetch.php
+++ b/src/Fetch.php
@@ -70,6 +70,8 @@ class Fetch
     private $curlOptions = [
         CURLOPT_CONNECTTIMEOUT => 10,
         CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_SSL_VERIFYPEER => false,
+        CURLOPT_SSL_VERIFYHOST => false
     ];
 
     /**


### PR DESCRIPTION
Update the curl option to skip the self signed certificate

https://www.php.net/manual/en/function.curl-setopt.php